### PR TITLE
fix: add explicit Jekyll build step to resolve 404 errors on documentation pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -253,14 +253,49 @@ jobs:
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      - name: Setup Ruby for Jekyll
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: false
+
+      - name: Create Gemfile for Jekyll
+        run: |
+          cd docs
+          cat > Gemfile << 'EOF'
+          source "https://rubygems.org"
+          gem "github-pages", group: :jekyll_plugins
+          gem "jekyll-github-metadata"
+          gem "jekyll-sitemap"
+          gem "jekyll-seo-tag"
+          EOF
+
+      - name: Install Jekyll dependencies
+        run: |
+          cd docs
+          bundle install
+
+      - name: Build Jekyll site
+        run: |
+          cd docs
+          echo "🔨 Building Jekyll site..."
+          bundle exec jekyll build --verbose
+          echo "✅ Jekyll site built successfully"
+          echo ""
+          echo "Checking built files in _site/:"
+          ls -la _site/ | head -20
+          echo ""
+          echo "Checking for HTML files:"
+          find _site -name "*.html" -type f | head -10
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire docs folder - Jekyll will process .md files, leave api/html/ as-is
-          path: './docs'
+          # Upload Jekyll-built site from docs/_site
+          path: './docs/_site'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,7 +45,27 @@ jobs:
           echo "🔍 Verifying Graphviz installation..."
           which dot
           dot -V
-          echo "✅ Graphviz (dot) is installed and accessible"
+
+          # Test that dot can actually generate SVG
+          echo "Testing dot SVG generation..."
+          echo 'digraph test { A -> B; }' | dot -Tsvg > /tmp/test.svg
+          if [ -s /tmp/test.svg ]; then
+            echo "✅ Graphviz (dot) is installed and can generate SVG files"
+          else
+            echo "❌ ERROR: dot installed but cannot generate SVG"
+            exit 1
+          fi
+
+          # Verify Doxyfile DOT_PATH setting
+          DOT_PATH_VALUE=$(grep "^DOT_PATH" Doxyfile | awk '{print $NF}')
+          echo "DOT_PATH in Doxyfile: '${DOT_PATH_VALUE}'"
+          if [ -z "$DOT_PATH_VALUE" ]; then
+            echo "⚠️  WARNING: DOT_PATH is empty - Doxygen may fail to find dot"
+          elif [ -x "$DOT_PATH_VALUE" ]; then
+            echo "✅ DOT_PATH points to executable file: $DOT_PATH_VALUE"
+          else
+            echo "⚠️  WARNING: DOT_PATH set but file not executable: $DOT_PATH_VALUE"
+          fi
 
       - name: Generate Doxygen documentation
         run: |
@@ -67,12 +87,40 @@ jobs:
           echo "🔍 Checking for generated SVG call graphs..."
           SVG_COUNT=$(find docs/api/html -name "*.svg" -type f | wc -l)
           echo "Found $SVG_COUNT SVG files"
+
           if [ $SVG_COUNT -gt 0 ]; then
             echo "✅ SVG graph files generated successfully"
-            echo "Sample SVG files:"
-            find docs/api/html -name "*call*.svg" -o -name "*caller*.svg" | head -5
+            echo ""
+            echo "Sample call graph SVG files:"
+            find docs/api/html -name "*_cgraph.svg" | head -5 | while read svg; do
+              echo "  - $(basename $svg)"
+            done
+            echo ""
+            echo "Sample caller graph SVG files:"
+            find docs/api/html -name "*_icgraph.svg" | head -5 | while read svg; do
+              echo "  - $(basename $svg)"
+            done
+
+            # Check for DOT files that weren't converted
+            DOT_COUNT=$(find docs/api/html -name "*.dot" -type f | wc -l)
+            if [ $DOT_COUNT -gt 0 ] && [ $SVG_COUNT -eq 0 ]; then
+              echo "❌ ERROR: Found .dot files but no .svg files - conversion failed!"
+              exit 1
+            fi
           else
-            echo "⚠️  Warning: No SVG files found - graphs may not be generated"
+            echo "❌ ERROR: No SVG files found - graphs were not generated!"
+            echo ""
+            echo "Checking for .dot files..."
+            DOT_COUNT=$(find docs/api/html -name "*.dot" -type f | wc -l)
+            if [ $DOT_COUNT -gt 0 ]; then
+              echo "Found $DOT_COUNT .dot files - this means Doxygen tried to generate"
+              echo "graphs but dot failed to convert them to SVG. Check dot configuration."
+              find docs/api/html -name "*.dot" | head -5
+            else
+              echo "No .dot files found either - Doxygen did not attempt graph generation."
+              echo "Check HAVE_DOT, CALL_GRAPH, CALLER_GRAPH settings in Doxyfile."
+            fi
+            exit 1
           fi
 
           echo ""

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,10 +40,42 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz
 
+      - name: Verify Graphviz installation
+        run: |
+          echo "🔍 Verifying Graphviz installation..."
+          which dot
+          dot -V
+          echo "✅ Graphviz (dot) is installed and accessible"
+
       - name: Generate Doxygen documentation
         run: |
-          doxygen Doxyfile
+          doxygen Doxyfile 2>&1 | tee doxygen.log
+          echo ""
           echo "✅ Doxygen documentation generated at docs/api/html/"
+          echo ""
+
+          # Check for any dot-related warnings or errors
+          if grep -i "warning.*dot" doxygen.log; then
+            echo "⚠️  Warning: Found dot-related warnings in Doxygen output"
+          fi
+          if grep -i "error.*dot" doxygen.log; then
+            echo "❌ Error: Found dot-related errors in Doxygen output"
+            exit 1
+          fi
+
+          # Verify SVG files were generated
+          echo "🔍 Checking for generated SVG call graphs..."
+          SVG_COUNT=$(find docs/api/html -name "*.svg" -type f | wc -l)
+          echo "Found $SVG_COUNT SVG files"
+          if [ $SVG_COUNT -gt 0 ]; then
+            echo "✅ SVG graph files generated successfully"
+            echo "Sample SVG files:"
+            find docs/api/html -name "*call*.svg" -o -name "*caller*.svg" | head -5
+          else
+            echo "⚠️  Warning: No SVG files found - graphs may not be generated"
+          fi
+
+          echo ""
           ls -la docs/api/html/ | head -20
 
       - name: Add .nojekyll to Doxygen output

--- a/Doxyfile
+++ b/Doxyfile
@@ -2858,7 +2858,7 @@ INTERACTIVE_SVG        = YES
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               =
+DOT_PATH               = /usr/bin/dot
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,34 +27,22 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
 
-# Collections
-collections:
-  docs:
-    output: true
-    permalink: /:collection/:path/
-
 # Defaults
 defaults:
   - scope:
       path: ""
-      type: "docs"
     values:
       layout: "default"
 
 # Include/Exclude
-include:
-  - README.md
-  - CHANGELOG.md
-  - build.md
-  - architecture.md
-
+# Jekyll will automatically copy api/ and images/ folders to _site/ as static assets
 exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
   - .gitignore
-  # Note: api/html/ is NOT excluded - it contains Doxygen HTML that must be served
-  # The .nojekyll file in api/html/ prevents Jekyll from processing those files
+  - .bundle
+  # Note: api/html/ is NOT excluded - it contains Doxygen HTML that must be served as static assets
 
 # SEO
 lang: en-US


### PR DESCRIPTION
Fixes 404 errors on index.html, build.html, and architecture.html by
explicitly building the Jekyll site before deployment.

Root cause:
- The previous workflow uploaded raw docs/ folder expecting GitHub Pages
  to process Jekyll automatically
- The collections configuration was interfering with normal page processing
- Jekyll needs to be explicitly built to convert .md files to .html

Changes to workflow:
1. Added Ruby setup and Jekyll installation steps
2. Create Gemfile with github-pages gem and required plugins
3. Build Jekyll site with `bundle exec jekyll build`
4. Upload the built _site/ folder instead of raw docs/ folder
5. Added verification to list generated HTML files

Changes to _config.yml:
1. Removed problematic collections configuration that was preventing
   normal markdown processing
2. Removed explicit include list (not needed for files in root)
3. Simplified defaults to apply to all pages
4. Added .bundle to exclude list

Result:
- Jekyll now properly converts index.md → index.html
- build.md → build.html, architecture.md → architecture.html
- Doxygen api/html/ folder copied as static assets (with call graphs!)
- All pages should now load correctly at their expected URLs

Closes https://github.com/OnesmoOgore/embedded-motor-pid-controller/issues/11 (call graphs working, Jekyll pages now also working)