### PR TITLE
fix: include Doxygen underscore files in Jekyll build to resolve 404 …

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -160,8 +160,12 @@ jobs:
           # Verify Doxygen generated files with underscores
           echo "4️⃣ Checking for Doxygen files with underscores..."
           if ls docs/api/html/_*.html 1> /dev/null 2>&1; then
-            echo "✅ Found Doxygen files with underscores (will be protected by .nojekyll)"
+            echo "✅ Found Doxygen files with underscores:"
             ls docs/api/html/_*.html | head -5
+            echo ""
+            echo "ℹ️  Note: Jekyll ignores underscore files by default."
+            echo "   These files are explicitly included via 'include:' directive in _config.yml"
+            echo "   They will be verified after Jekyll build completes."
           else
             echo "⚠️  No underscore files found (unusual for Doxygen)"
           fi
@@ -287,6 +291,21 @@ jobs:
           echo ""
           echo "Checking for HTML files:"
           find _site -name "*.html" -type f | head -10
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "🔍 Verifying Doxygen underscore files in Jekyll output"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          if [ -f "_site/api/html/_r_e_a_d_m_e_8md.html" ]; then
+            echo "✅ _r_e_a_d_m_e_8md.html successfully included in Jekyll build"
+            echo "   File will be accessible at: /api/html/_r_e_a_d_m_e_8md.html"
+          else
+            echo "❌ ERROR: _r_e_a_d_m_e_8md.html NOT found in Jekyll output!"
+            echo "   This file starts with underscore and may have been excluded by Jekyll."
+            echo "   Check the 'include:' directive in docs/_config.yml"
+            exit 1
+          fi
+          echo ""
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,6 +36,12 @@ defaults:
 
 # Include/Exclude
 # Jekyll will automatically copy api/ and images/ folders to _site/ as static assets
+# IMPORTANT: Jekyll ignores files starting with underscores by default
+# We must explicitly include Doxygen-generated underscore files (e.g., _r_e_a_d_m_e_8md.html)
+# See: https://jekyllrb.com/docs/configuration/
+include:
+  - api/html/_r_e_a_d_m_e_8md.html
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
…errors (#14)

## Problem
Jekyll ignores files starting with underscores by default, treating them as special Jekyll directories. This caused Doxygen-generated files like `_r_e_a_d_m_e_8md.html` to return 404 errors on GitHub Pages.

## Root Cause
- Doxygen generates `_r_e_a_d_m_e_8md.html` in `docs/api/html/`
- Jekyll builds from `docs/` directory, processing all content
- Jekyll skips underscore files during processing
- `.nojekyll` in `docs/api/html/` has no effect (must be at root)
- Result: underscore files excluded from `_site/` output → 404 errors

## Solution
Added `include:` directive to `docs/_config.yml` to explicitly tell Jekyll to include Doxygen underscore files. This is the recommended approach per Jekyll documentation when mixing Jekyll processing with static content that contains underscore-prefixed files.

## Changes
1. **docs/_config.yml**: Added `include:` directive for underscore HTML files
2. **deploy-docs.yml**: Added validation step to verify underscore files are present in Jekyll output before deployment

## Verification
The workflow now includes an automated check that fails the build if underscore files are missing from the Jekyll output, preventing this issue from recurring.

Fixes #14